### PR TITLE
feat: completion for % and @

### DIFF
--- a/i.sh
+++ b/i.sh
@@ -3,9 +3,7 @@ I_PATH=~/i
 I_SOURCE_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 I_GPT_VERSION="${I_GPT_VERSION:=gpt-4}"
 
-complete -W "amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse" i
-
-# TODO add completion for names and tags
+complete -F __i_completion i
 
 since=""
 
@@ -237,6 +235,24 @@ for line in sys.stdin:
 		pass  # ignore lines that are not valid JSON
 "
 }
+
+function __i_unique_occurrences_completion {
+	__i_list | sed 's/\ /\n/g' | grep ${1} --color=never | sed 's/,//g; s/\.//g' | sort | uniq | sort -rh | tr '\n' ' ' | xargs
+}
+
+function __i_completion {
+	local cur_word
+    cur_word="${COMP_WORDS[COMP_CWORD]}"
+    if [[ "$cur_word" == "@"* ]]; then
+        words=$(__i_unique_occurrences_completion @)
+	elif [[ "$cur_word" == "%"* ]]; then
+		words=$(__i_unique_occurrences_completion %)
+	else
+		words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
+	fi
+	COMPREPLY+=($(compgen -W "${words}" "${COMP_WORDS[1]}"))
+}
+
 
 # do an init of the i repo if we detect it isn't there
 if [ ! -e "$I_PATH" ]; then

--- a/i.sh
+++ b/i.sh
@@ -236,10 +236,12 @@ for line in sys.stdin:
 "
 }
 
+# used to create a list of unique occurrences of a specific character
 function __i_unique_occurrences_completion {
 	__i_list | sed 's/\ /\n/g' | grep ${1} --color=never | sed 's/,//g; s/\.//g' | sort | uniq | sort -rh | tr '\n' ' '
 }
 
+# used to power tab completion for the @ and % characters & default
 function __i_completion {
 	local cur_word
 	cur_word="${COMP_WORDS[COMP_CWORD]}"
@@ -252,7 +254,6 @@ function __i_completion {
 	@*) words=$(__i_unique_occurrences_completion @ ) ;;
 	esac
 
-	# __i_unique_occurrences @
 	COMPREPLY+=($(compgen -W "${words}" "${COMP_WORDS[COMP_CWORD]}"))
 }
 

--- a/i.sh
+++ b/i.sh
@@ -237,7 +237,7 @@ for line in sys.stdin:
 }
 
 function __i_unique_occurrences_completion {
-	__i_list | sed 's/\ /\n/g' | grep ${1} --color=never | sed 's/,//g; s/\.//g' | sort | uniq | sort -rh | tr '\n' ' ' | xargs
+	__i_list | sed 's/\ /\n/g' | grep ${1} --color=never | sed 's/,//g; s/\.//g' | sort | uniq | sort -rh | tr '\n' ' '
 }
 
 function __i_completion {

--- a/i.sh
+++ b/i.sh
@@ -242,14 +242,17 @@ function __i_unique_occurrences_completion {
 
 function __i_completion {
 	local cur_word
-	cur_word="${COMP_WORDS[COMP_CWORD]}"
-	if [[ "$cur_word" == "@"* ]]; then
-		words=$(__i_unique_occurrences_completion @)
-	elif [[ "$cur_word" == "%"* ]]; then
-		words=$(__i_unique_occurrences_completion %)
-	else
-		words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
-	fi
+    cur_word="${COMP_WORDS[COMP_CWORD]}"
+
+	local words
+	words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
+
+	case $cur_word in
+	%*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
+	@*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
+	esac
+
+	# __i_unique_occurrences @
 	COMPREPLY+=($(compgen -W "${words}" "${COMP_WORDS[1]}"))
 }
 

--- a/i.sh
+++ b/i.sh
@@ -249,7 +249,7 @@ function __i_completion {
 
 	case $cur_word in
 	%*) words=$(__i_unique_occurrences_completion % ) ;;
-	@*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
+	@*) words=$(__i_unique_occurrences_completion @ ) ;;
 	esac
 
 	# __i_unique_occurrences @

--- a/i.sh
+++ b/i.sh
@@ -248,7 +248,7 @@ function __i_completion {
 	words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
 
 	case $cur_word in
-	%*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
+	%*) words=$(__i_unique_occurrences_completion % ;;
 	@*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
 	esac
 

--- a/i.sh
+++ b/i.sh
@@ -242,7 +242,7 @@ function __i_unique_occurrences_completion {
 
 function __i_completion {
 	local cur_word
-    cur_word="${COMP_WORDS[COMP_CWORD]}"
+	cur_word="${COMP_WORDS[COMP_CWORD]}"
 
 	local words
 	words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
@@ -253,7 +253,7 @@ function __i_completion {
 	esac
 
 	# __i_unique_occurrences @
-	COMPREPLY+=($(compgen -W "${words}" "${COMP_WORDS[1]}"))
+	COMPREPLY+=($(compgen -W "${words}" "${COMP_WORDS[COMP_CWORD]}"))
 }
 
 

--- a/i.sh
+++ b/i.sh
@@ -242,9 +242,9 @@ function __i_unique_occurrences_completion {
 
 function __i_completion {
 	local cur_word
-    cur_word="${COMP_WORDS[COMP_CWORD]}"
-    if [[ "$cur_word" == "@"* ]]; then
-        words=$(__i_unique_occurrences_completion @)
+	cur_word="${COMP_WORDS[COMP_CWORD]}"
+	if [[ "$cur_word" == "@"* ]]; then
+		words=$(__i_unique_occurrences_completion @)
 	elif [[ "$cur_word" == "%"* ]]; then
 		words=$(__i_unique_occurrences_completion %)
 	else

--- a/i.sh
+++ b/i.sh
@@ -248,7 +248,7 @@ function __i_completion {
 	words="amend list mentioned tagged find occurrences git upgrade today yesterday digest remember analyse"
 
 	case $cur_word in
-	%*) words=$(__i_unique_occurrences_completion % ;;
+	%*) words=$(__i_unique_occurrences_completion % ) ;;
 	@*) words=$(__i_unique_occurrences_completion @ | sed 's/@[^A-Za-z0-9]//g') ;;
 	esac
 


### PR DESCRIPTION
Adds completion for `@` and `%` symbols.

Tested locally

```
reeldata:~/w/i-devlog $ i 
amend        analyse      digest       find         git          list         mentioned    occurrences  remember     tagged       today        upgrade      yesterday    
reeldata:~/w/i-devlog $ i @
@AdamFiction      @JustinMark  @lrwm3
reeldata:~/w/i-devlog $ i %
%test-project-1  %project-2
```