### PR TITLE
feat - list & analyse supports since and until

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ source i.sh #this creates your journal repo at ~/i
 
 > You can 'mention' names with `@` and 'tag' things with `%`.
 
+### List entries between time range
+
+```bash
+❯ i list since "30 minutes ago"
+
+21 minutes ago: went for a walk
+
+❯ i list until "60 minutes ago"
+
+79 minutes ago: created a journal
+
+❯ i list until "50 minutes ago" since "60 minutes ago"
+
+54 minutes ago: spoke to @john
+
+54 minutes ago: added an entry
+
+❯ i list since "60 minutes ago" until "50 minutes ago"
+
+54 minutes ago: spoke to @john
+
+54 minutes ago: added an entry
+```
+
+> See the official git documentation, [date-formats.txt](https://raw.githubusercontent.com/git/git/master/Documentation/date-formats.txt) for all possible date and time representations `since` and `until` support.
+
 ### List mentions
 
 ```bash
@@ -55,7 +81,7 @@ source i.sh #this creates your journal repo at ~/i
    2 @fred
    1 @linda
    1 @kelly
-```` 
+```
 
 ### List specific entries for people
 

--- a/i.sh
+++ b/i.sh
@@ -170,7 +170,7 @@ function __i_amend {
 # the syntax is `i list` or 
 # the syntax is `i list since "last monday" until "yesterday"`
 function __i_list {
-    item="${1}"
+	item="${1}"
 	local until_cmd since_cmd
 
 	while [ "$item" == "until" ] || [ "$item" == "since" ] && [ -n "${2}" ]; do

--- a/i.sh
+++ b/i.sh
@@ -121,7 +121,7 @@ function __i_help {
   echo ""
   echo "COMMANDS:"
   echo "  amend            Overwrite the last message - useful in case of missing info or typos."
-  echo "  list             List out the journal."
+  echo "  list             List out the journal. Optionally, you can specify a date range using 'since' and 'until'."
   echo "  mentioned        List out names mentioned or entries where a specific person is mentioned."
   echo "  tagged           List out tags mentioned or entries where a specific tag is mentioned."
   echo "  find             Generic find for anything."

--- a/i.sh
+++ b/i.sh
@@ -121,7 +121,7 @@ function __i_help {
   echo ""
   echo "COMMANDS:"
   echo "  amend            Overwrite the last message - useful in case of missing info or typos."
-  echo "  list             List out the journal. Optionally, you can specify a date range using 'since' and 'until'."
+  echo "  list             List out the journal."
   echo "  mentioned        List out names mentioned or entries where a specific person is mentioned."
   echo "  tagged           List out tags mentioned or entries where a specific tag is mentioned."
   echo "  find             Generic find for anything."
@@ -171,6 +171,7 @@ function __i_amend {
 # the syntax is `i list "last monday"`
 function __i_list {
     item="${1}"
+	local until_cmd since_cmd
 
     while [ "$item" == "until" ] || [ "$item" == "since" ]; do
         if [ "$item" == "until" ]; then

--- a/i.sh
+++ b/i.sh
@@ -166,8 +166,15 @@ function __i_amend {
 }
 
 # list the entries in readable format
+# the syntax is `i list` or 
+# the syntax is `i list "last monday"`
 function __i_list {
-	git -C $I_PATH/ log --since "${since:-1970}" --pretty=format:"%Cblue%cr: %Creset%B";
+	logUntil="${1}"
+	if [ "$logUntil" == "" ]; then # allow user to type "list" as first argument
+		git -C $I_PATH/ log --since "${since:-1970}" --pretty=format:"%Cblue%cr: %Creset%B";
+	else
+		git -C $I_PATH/ log --since "${since:-1970}" --until=$logUntil --pretty=format:"%Cblue%cr: %Creset%B";
+	fi
 }
 
 function __i_count_occurrences {

--- a/i.sh
+++ b/i.sh
@@ -168,7 +168,7 @@ function __i_amend {
 
 # list the entries in readable format
 # the syntax is `i list` or 
-# the syntax is `i list "last monday"`
+# the syntax is `i list since "last monday" until "yesterday"`
 function __i_list {
     item="${1}"
 	local until_cmd since_cmd

--- a/i.sh
+++ b/i.sh
@@ -18,7 +18,8 @@ function i {
 			__i_amend "$@"; return;;
 
 		"list" ) # list out the journal
-			__i_list; return;;
+			shift
+			__i_list "$@"; return;;
 
 		"mentioned") # list out names mentioned
 			shift
@@ -169,12 +170,20 @@ function __i_amend {
 # the syntax is `i list` or 
 # the syntax is `i list "last monday"`
 function __i_list {
-	logUntil="${1}"
-	if [ "$logUntil" == "" ]; then # allow user to type "list" as first argument
-		git -C $I_PATH/ log --since "${since:-1970}" --pretty=format:"%Cblue%cr: %Creset%B";
-	else
-		git -C $I_PATH/ log --since "${since:-1970}" --until=$logUntil --pretty=format:"%Cblue%cr: %Creset%B";
-	fi
+    item="${1}"
+
+    while [ "$item" == "until" ] || [ "$item" == "since" ]; do
+        if [ "$item" == "until" ]; then
+            until_cmd="${2}"
+            shift 2
+        elif [ "$item" == "since" ]; then
+            since_cmd="${2}"
+            shift 2
+        fi
+        item="${1}"
+    done
+
+	git -C $I_PATH/ log --since "${since_cmd:=1970}" --until "${until_cmd:=now}" --pretty=format:"%Cblue%cr: %Creset%B";
 }
 
 function __i_count_occurrences {

--- a/i.sh
+++ b/i.sh
@@ -173,14 +173,13 @@ function __i_list {
     item="${1}"
 	local until_cmd since_cmd
 
-    while [ "$item" == "until" ] || [ "$item" == "since" ]; do
+	while [ "$item" == "until" ] || [ "$item" == "since" ] && [ -n "${2}" ]; do
         if [ "$item" == "until" ]; then
             until_cmd="${2}"
-            shift 2
         elif [ "$item" == "since" ]; then
             since_cmd="${2}"
-            shift 2
         fi
+		shift 2
         item="${1}"
     done
 

--- a/i.sh
+++ b/i.sh
@@ -174,14 +174,14 @@ function __i_list {
 	local until_cmd since_cmd
 
 	while [ "$item" == "until" ] || [ "$item" == "since" ] && [ -n "${2}" ]; do
-        if [ "$item" == "until" ]; then
-            until_cmd="${2}"
-        elif [ "$item" == "since" ]; then
-            since_cmd="${2}"
-        fi
+		if [ "$item" == "until" ]; then
+			until_cmd="${2}"
+		elif [ "$item" == "since" ]; then
+			since_cmd="${2}"
+		fi
 		shift 2
-        item="${1}"
-    done
+		item="${1}"
+	done
 
 	git -C $I_PATH/ log --since "${since_cmd:=1970}" --until "${until_cmd:=now}" --pretty=format:"%Cblue%cr: %Creset%B";
 }

--- a/i.sh
+++ b/i.sh
@@ -216,18 +216,23 @@ function __i_find {
 }
 
 # run arbitrary GPT analysis commands on a specific time window from the journal
-# the syntax is `i analyse since "last monday" list all people i interacted with`
+# the syntax is `i analyse since "last monday" until "yesterday" list all people i interacted with`
 function __i_analyse { 
 	item="${1}"
-	shift
+	local until_cmd since_cmd
 
-	if [ "$item" == "since" ]; then # allow user to type "since" as first argument
+	while [ "$item" == "until" ] || [ "$item" == "since" ] && [ -n "${2}" ]; do
+		if [ "$item" == "until" ]; then
+			until_cmd="${2}"
+		elif [ "$item" == "since" ]; then
+			since_cmd="${2}"
+		fi
+		shift 2
 		item="${1}"
-		shift
-	fi
+	done
 
 	# the journal
-	OUT=$(git -C $I_PATH/ log --since "$item" --pretty=format:"%cr: %B" | tr -d '"\n')
+	OUT=$(git -C $I_PATH/ log --since "${since_cmd:=1970}" --until "${until_cmd:=now}" --pretty=format:"%cr: %B" | tr -d '"\n')
 	# the whole prompt
 	PROMPT="$* \n\n\n "$OUT""
 
@@ -342,5 +347,5 @@ fi
 
 # Check if the script is being executed directly. If so, we run i directly
 if [[ "${BASH_SOURCE[0]}" = "${0}" ]]; then
-    i "$@"
+	i "$@"
 fi


### PR DESCRIPTION
I was accessing my log today, trying to see what I did over the last two weeks to fill out a timesheet.

However, it was somewhat challenging to see what I did on a particular day.

I could have used the `i git` as an override, but I thought it would be nice to include support for 'since' and 'until' in the list command.

This PR adds `since` and `until` support to `i list` to make it easier to see what I did on a given day.